### PR TITLE
Various build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ try to reconstruct higher level types from the types of record fields:
    * The `sType`,`pNext` idiom used to extend records is mapped to a proper
    open sum types.
 
-A array function (`t list -> t Ctypes.CArray) is also provided to ensure that
+An array function (`t list -> t Ctypes.CArray`) is also provided to ensure that
 the GC does not collect the values living on the C side too soon.
 
 ## Function pointer

--- a/olivine.opam
+++ b/olivine.opam
@@ -15,6 +15,7 @@ build:[
 
 depends: [
   "dune" {build}
+  "ppxlib" {>= "0.20.0"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree"
   "xmlm"

--- a/olivine.opam
+++ b/olivine.opam
@@ -16,8 +16,6 @@ build:[
 depends: [
   "dune" {build}
   "ppxlib" {>= "0.20.0"}
-  "ppx_tools_versioned"
-  "ocaml-migrate-parsetree"
   "xmlm"
   "fmt"
   "menhir" {build}


### PR DESCRIPTION
- It doesn't build with ppxlib 0.15.0, so require 0.20.0 instead.
- Remove `ppx_tools_versioned` and `ocaml-migrate-parsetree` dependencies. They prevent building on newer versions of OCaml, and weren't being used for anything anyway.

Also fixed some markdown syntax in `README.md`.