### PR TITLE
Improve README and simplify code a bit

### DIFF
--- a/generator/libgen.ml
+++ b/generator/libgen.ml
@@ -33,7 +33,7 @@ let () =
   try
     let info = read Sys.argv.(1) in
     let dict, _exts = Info.Vulkan_dialect.make info in
-    let lib = Aster.Lib.generate (I.item [] []) dict info in
+    let lib = Aster.Lib.generate dict info in
     if Array.length Sys.argv > 2 then (
       let root = Sys.argv.(2) in
       Printer.lib root lib

--- a/generator/printer.ml
+++ b/generator/printer.ml
@@ -102,6 +102,7 @@ let rec submodules = function
   | _ :: q -> submodules q
   | [] -> []
 
+(* Generate the top-level Vk module with links to all the other generated submodules. *)
 let atlas (close,ppfs) modules =
   let rec pp_alias delim current ppfs (m:B.module') =
     let path = current @ [m.name] in
@@ -152,8 +153,7 @@ let lib root (lib:B.lib) =
           let filename = Fmt.str "%a" pp_concrete_name path in
           let close, ppfs = open_files filename in
           let ast =
-            I.( lib.preambule @*
-                I.fold_map (item_to_ast [m.name] lib) m.sig')
+            I.(fold_map (item_to_ast [m.name] lib) m.sig')
           in
           print Str pps (str ppfs) ast;
           print Sig pps (sg ppfs) ast;
@@ -162,7 +162,7 @@ let lib root (lib:B.lib) =
           close ();
         end
       end
-    else Fmt.epr "Printing %a submodule@.%!" L.pp_var m.name
+    else Fmt.epr "Not printing empty %a submodule@.%!" L.pp_var m.name
   in
   List.iter (pp_sub L.[~:"vk"]) @@ submodules lib.content.sig'
 


### PR DESCRIPTION
This adds an `Internals` section to the README, which gives a high-level overview of how the generator works.

I also added a few comments to the code and removed some confusing bits that didn't seem to be used for anything. e.g. `lib.preambule` is gone, as it was always empty. The generated code is the same.

Note: this PR is on top of #14, but could be rebased on `main` without much trouble.