### PR TITLE
Fix segfault in GC finalisers

### DIFF
--- a/lib/vk__builtin__handle.ml
+++ b/lib/vk__builtin__handle.ml
@@ -41,12 +41,12 @@ struct
 
   let array l =
     let a = Ctypes.CArray.of_list t l in
-    Gc.finalise ( fun _ -> let _kept_alive = ref l in () ) a;
+    Vk__helpers.keep_alive (ref l) a;
     a
 
   let array_opt l =
     let a = Ctypes.CArray.of_list ctype_opt (List.map (fun x -> Some x) l) in
-    Gc.finalise ( fun _ -> let _kept_alive = ref l in () ) a;
+    Vk__helpers.keep_alive (ref l) a;
     a
 
 
@@ -74,12 +74,12 @@ struct
 
   let array l =
     let a = Ctypes.CArray.of_list t l in
-    Gc.finalise ( fun _ -> let _kept_alive = ref l in () ) a;
+    Vk__helpers.keep_alive (ref l) a;
     a
 
   let array_opt l =
     let a = Ctypes.CArray.of_list ctype_opt (List.map (fun x -> Some x) l) in
-    Gc.finalise ( fun _ -> let _kept_alive = ref l in () ) a;
+    Vk__helpers.keep_alive (ref l) a;
     a
 
   let to_int64 x = x

--- a/lib/vk__helpers.ml
+++ b/lib/vk__helpers.ml
@@ -25,6 +25,12 @@ let convert_string n s =
   done;
   a
 
+(* Keep [x] alive as long as [owner] is. *)
+let keep_alive x owner =
+  try
+    Gc.finalise_last (fun () -> ignore (Sys.opaque_identity x)) owner
+  with Invalid_argument _ -> () (* [owner] may be an empty list - FIXME *)
+
 module Pp = struct
 
   let opt pp ppf = function


### PR DESCRIPTION
When a C struct refers to other C memory, we need to keep the targets alive. This is done by attaching a finaliser to the OCaml value pointing at the first struct, where the finaliser holds an OCaml value that points at the targets.

Previously, this was done using `[| Obj.repr field1; Obj.repr field2 |]`. However, this fails if `field1` is a float and `field2` isn't as OCaml will try to convert it to a float-array. This will cause a segfault.

It now uses a tuple instead when there are multiple fields, and adds the missing `Sys.opaque_identity` (as suggested by Florian Angeletti).

~~The old code was also catching and ignoring `Invalid_argument` (6b636fb48ea8). I removed this as I don't think it can happen, and if it does we probably want to know about it.~~ Added a comment about when this happens.

Fixes #17.